### PR TITLE
Add lifecycle rule ignoring changes to definition

### DIFF
--- a/README-holler.md
+++ b/README-holler.md
@@ -1,20 +1,29 @@
-# Holler README
-This is a fork of the [terraform-aws-modules/terraform-aws-step-functions](https://github.com/terraform-aws-modules/terraform-aws-step-functions) repository. To work on this repo, do the following.
+# Holler Notes
+This is a fork of the [terraform-aws-modules/terraform-aws-step-functions](https://github.com/terraform-aws-modules/terraform-aws-step-functions) repository. This is a **PUBLIC REPOSITORY** and all branches, commit messages, pull requests, etc, are public. Keep this in mind as you work on this repo.
 
-1. Clone this repo: `git clone git@github.com:emogi/terraform-aws-step-functions.git`
-1. Add upstream repo: `git remote add --track master upstream git@github.com:terraform-aws-modules/terraform-aws-step-functions.git`
 
-I have created a `holler` branch as follows.
+To work on this repo, do the following.
+
+```
+git clone git@github.com:emogi/terraform-aws-step-functions.git
+git remote add --track master upstream git@github.com:terraform-aws-modules/terraform-aws-step-functions.git
+```
+
+A `holler` branch was created as follows. This branch contains the code used at Holler.
 
 ```
 git checkout -b holler v2.5.0
 ```
 
-We will tag our releases based on the upstream version on which we base our changes. For example
+We will tag our releases based on the upstream version on which we base our changes. For example,
 
 ```
+git checkout holler
 vim whatever.tf
 git commit
 git push
 git tag -a v2.5.0-holler
 ```
+
+## CHANGELOG
+* 2021-11-16: Add `lifecycle` rule to resource `aws_sfn_state_machine.this`, ignoring changes to the `definitions` variable. This change cannot be pushed upstream because terraform does not support dynamic blocks for lifecycle rules, nor does terraform support variables inside a lifecycle rule ([issue](https://github.com/hashicorp/terraform/issues/3116))

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,13 @@ resource "aws_sfn_state_machine" "this" {
   type = upper(var.type)
 
   tags = merge({ Name = var.name }, var.tags)
+
+  lifecycle {
+    ignore_change = [
+      # Function definition controlled by CircleCI deployment script
+      definition,
+    ]
+  }
 }
 
 ###########


### PR DESCRIPTION
Adds a lifecycle rule ignoring changes to the `definition` variable so we can manage function defs outside terraform.